### PR TITLE
Improve markup of tabs

### DIFF
--- a/portal-web/docroot/html/taglib/ui/tabs/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/tabs/start.jsp
@@ -168,7 +168,7 @@ String onClick = GetterUtil.getString((String)request.getAttribute("liferay-ui:t
 			cssClassName += " first";
 		}
 
-		if ((i == values.length - 1) && Validator.isNull(backURL)) {
+		if (i == values.length - 1) {
 			cssClassName += " last";
 		}
 	%>
@@ -236,8 +236,8 @@ String onClick = GetterUtil.getString((String)request.getAttribute("liferay-ui:t
 				/>
 			</c:when>
 			<c:otherwise>
-				<li class="aui-tab toggle last">
-					<span class="aui-tab-content">
+				<li class="aui-tab-back toggle last">
+					<span class="aui-tab-back-content">
 						<span class="aui-tab-label">
 							<a href="<%= backURL %>" id="<%= namespace %><%= param %>TabsBack"><%= Validator.isNotNull(backLabel) ? backLabel : "&laquo;" + LanguageUtil.get(pageContext, "back") %></a>
 						</span>

--- a/portal-web/docroot/html/themes/_styled/css/application.css
+++ b/portal-web/docroot/html/themes/_styled/css/application.css
@@ -346,6 +346,10 @@
 	font-weight: normal;
 }
 
+.aui-tab-back {
+	float: right;
+}
+
 /* ---------- Misc. ---------- */
 
 .lfr-panel-container {


### PR DESCRIPTION
This pull request includes 2 commits: 
- LPS-23617 tabs markups should be different for selected tab
- LPS-23619 Back link in tabs shouldn't look like a tab
