### PR TITLE
LPS-12681

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/cache/CacheFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/cache/CacheFilter.java
@@ -215,7 +215,7 @@ public class CacheFilter extends BasePortalFilter {
 		}
 
 		if (Validator.isNull(friendlyURL)) {
-			try { 
+			try {
 				return LayoutLocalServiceUtil.getDefaultPlid(
 					groupId, privateLayout);
 			} catch (SystemException se) {


### PR DESCRIPTION
Hi Sergio,

This is an issue comes in a special case: when you call the portal with /web/guest url suffix only the default page was not cached. When you used /web/guest/home it was working correctly.

So based on the layout's friendly URL missing or not the default layout was returned from cache or not.

With this fix the time per request goes down from 29 ms to 2 ms.

Thanks,

Máté
