### PR TITLE
LPS-24535 UUID is not considered on initial export of a user to LDAP

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/ldap/BasePortalToLDAPConverter.java
+++ b/portal-impl/src/com/liferay/portal/security/ldap/BasePortalToLDAPConverter.java
@@ -189,6 +189,9 @@ public class BasePortalToLDAPConverter implements PortalToLDAPConverter {
 		attributes.put(objectClass);
 
 		addAttributeMapping(
+			userMappings.getProperty(UserConverterKeys.UUID),
+			user.getUuid(), attributes);
+		addAttributeMapping(
 			userMappings.getProperty(UserConverterKeys.SCREEN_NAME),
 			user.getScreenName(), attributes);
 		addAttributeMapping(


### PR DESCRIPTION
Hi Sergio,

This is quite a small fix. In LDAP for the LDAP fields there is a mode when that field cannot be empty or null. When the UUID in LDAP cannot be empty the inital push from Liferay to LDAP fails, because we haven't pushed UUID to it for the first time. For later updates wo do push UUID as far as I know.

This change will make the portal to push the UUID for the first time as well.

Daniel tested the fix, but I haven't set up an LDAP yet. Since it looks like a small change I wanted to forward the pull request first.

Thanks,

Máté
