### PR TITLE
LPS-24221 StripFilter affecting content of pre elements

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/strip/StripFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/strip/StripFilter.java
@@ -638,7 +638,7 @@ public class StripFilter extends BasePortalFilter {
 	private static final int[] _MARKER_PRE_CLOSE_NEXTS =
 		KMPSearch.generateNexts(_MARKER_PRE_CLOSE);
 
-	private static final char[] _MARKER_PRE_OPEN = "pre>".toCharArray();
+	private static final char[] _MARKER_PRE_OPEN = "pre".toCharArray();
 
 	private static final String _MARKER_SCRIPT_CLOSE = "</script>";
 


### PR DESCRIPTION
Hi Sergio,

Copied from the ticket:

If a pre element has attributes (like <pre class="foobar">...</pre>), StripFilter will remove all whitespaces of the element's contents.

This fix will solve this problem.

Thanks,

Máté
