### PR TITLE
LPS-25154 Page tree does not show the selected page in Manage Site Pages

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1082,6 +1082,8 @@ public class ServicePreAction extends Action {
 				siteMapSettingsURL.setParameter("closeRedirect", currentURL);
 				siteMapSettingsURL.setParameter(
 					"groupId", String.valueOf(scopeGroupId));
+				siteMapSettingsURL.setParameter(
+					"selPlid", String.valueOf(plid));
 				siteMapSettingsURL.setPortletMode(PortletMode.VIEW);
 				siteMapSettingsURL.setWindowState(LiferayWindowState.POP_UP);
 


### PR DESCRIPTION
Hi Sergio,

This is a small inconsistency on trunk, however when it will be backported to 6.0.x some more serious problem will be solved. On 6.0.x the tree on manage pages screen are not even displayed in some cases.

Thanks,

Máté
