### PR TITLE
LPS-25902 Marking structure fields as non-searchable has no effect

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/util/JournalIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/journal/util/JournalIndexer.java
@@ -195,7 +195,8 @@ public class JournalIndexer extends BaseIndexer {
 				}
 
 				document.addText(
-					Field.CONTENT.concat(StringPool.UNDERLINE).concat(languageId),
+					Field.CONTENT.concat(StringPool.UNDERLINE).concat(
+						languageId),
 					content);
 			}
 		}


### PR DESCRIPTION
LPS-25902 Marking structure fields as non-searchable has no effect
