### PR TITLE
[TECH SUPPORT] LPS-46597 

### DIFF
--- a/portal-impl/src/com/liferay/portal/repository/BaseRepositoryFactory.java
+++ b/portal-impl/src/com/liferay/portal/repository/BaseRepositoryFactory.java
@@ -17,7 +17,6 @@ package com.liferay.portal.repository;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.bean.ClassLoaderBeanHandler;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.lar.ExportImportThreadLocal;
 import com.liferay.portal.kernel.repository.BaseRepository;
 import com.liferay.portal.kernel.repository.InvalidRepositoryIdException;
 import com.liferay.portal.kernel.repository.RepositoryException;
@@ -145,9 +144,7 @@ public abstract class BaseRepositoryFactory<T> {
 
 		setupRepository(repositoryId, repository, baseRepository);
 
-		if (!ExportImportThreadLocal.isImportInProcess()) {
-			baseRepository.initRepository();
-		}
+		baseRepository.initRepository();
 
 		return baseRepository;
 	}

--- a/portal-impl/src/com/liferay/portal/repository/cmis/CMISRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/cmis/CMISRepository.java
@@ -18,6 +18,7 @@ import com.liferay.portal.NoSuchRepositoryEntryException;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.lar.ExportImportThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.RepositoryException;
@@ -913,6 +914,10 @@ public class CMISRepository extends BaseCmisRepository {
 
 	@Override
 	public void initRepository() throws PortalException {
+		if (ExportImportThreadLocal.isImportInProcess()) {
+			return;
+		}
+
 		try {
 			_sessionKey =
 				Session.class.getName().concat(StringPool.POUND).concat(


### PR DESCRIPTION
Hey Sergio,

This is a small bugfix although it affects how the repositories being initialized.

The problem happens when someone is using the documentum hook with staging. During import the staging process replaces the DL references in the contents (web content, blogs, etc) as the staging code is calling out to the repository the documentum is not initialized due the the code piece in the BaseRepositoryFactory, and the process fails there.

But as the CMIS works differently we do not need to init the repo there, so Ákos applied the code for the CMIS if we are importing we should skip the init.

Thanks,

Máté
