### PR TITLE
LPS-55619 File Entry still has the old value of it's version field after reverting

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -1611,7 +1611,7 @@ public class DLFileEntryLocalServiceImpl
 		String extraSettings = dlFileVersion.getExtraSettings();
 		long fileEntryTypeId = dlFileVersion.getFileEntryTypeId();
 		Map<String, DDMFormValues> ddmFormValuesMap = null;
-		InputStream is = getFileAsStream(userId, fileEntryId, version);
+		InputStream is = getFileAsStream(fileEntryId, version, false);
 		long size = dlFileVersion.getSize();
 
 		serviceContext.setCommand(Constants.REVERT);


### PR DESCRIPTION
Hey @sergiogonzalez 

If a document's version is getting reverted, the version field of the file entry won't be updated in the database.
Strictly speaking, in will be updated, but an asynchronous call to incrementViewCounter() will overwrite the new version with the old as a side effect, because it holds dlFileEntry in it's own separate thread, which still holds the old value of the version field.

The change in the pull prevents incrementing view counter, which operation is itself not necessary in the process of reverting the document version.

Could you please review this pull?

Thank you.

Best regards,
István
