### PR TITLE
LPS-59047 Orphaned Subscription records stay in the database even after applying LPS-45418

### DIFF
--- a/portal-impl/src/com/liferay/portal/verify/VerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProcessSuite.java
@@ -45,6 +45,7 @@ public class VerifyProcessSuite extends VerifyProcess {
 		verify(new VerifyPortletPreferences());
 		verify(new VerifyRatings());
 		verify(new VerifyResourcePermissions());
+		verify(new VerifySubscriptions());
 		verify(new VerifySocial());
 		verify(new VerifyUser());
 		verify(new VerifyWorkflow());

--- a/portal-impl/src/com/liferay/portal/verify/VerifySubscriptions.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifySubscriptions.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.verify;
+
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.model.PortletPreferences;
+import com.liferay.portal.service.SubscriptionLocalServiceUtil;
+import com.liferay.portal.util.PortalUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Istvan Andras Dezsi
+ */
+public class VerifySubscriptions extends VerifyProcess {
+
+	protected void deleteOrphanedSubscriptions() throws Exception {
+		Connection con = null;
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+
+		try {
+			long classNameId = PortalUtil.getClassNameId(
+				PortletPreferences.class.getName());
+
+			con = DataAccess.getUpgradeOptimizedConnection();
+
+			StringBundler sb = new StringBundler(5);
+
+			sb.append("select subscriptionId from Subscription where ");
+			sb.append("classNameId = ");
+			sb.append(classNameId);
+			sb.append(" and classPK not in (select portletPreferencesId from ");
+			sb.append("PortletPreferences)");
+
+			ps = con.prepareStatement(sb.toString());
+
+			rs = ps.executeQuery();
+
+			while (rs.next()) {
+				long subscriptionId = rs.getLong("subscriptionId");
+
+				SubscriptionLocalServiceUtil.deleteSubscription(subscriptionId);
+			}
+		}
+		finally {
+			DataAccess.cleanUp(con, ps, rs);
+		}
+	}
+
+	@Override
+	protected void doVerify() throws Exception {
+		deleteOrphanedSubscriptions();
+	}
+
+}


### PR DESCRIPTION
Hey @sergiogonzalez 

Could you please review this pull?

This is a new Verify process which purges the Subscriptions with a classNameId if PortletPreferences and whose classPK does not match any portletPreferencesId.

Before LPS-45418, if an Asset Publisher portlet was removed which had a subscription, only the portletPreference entry was deleted, but not the subscription entry. After LPS-45418 both these entries are deleted, however, the subscriptions with no corresponding portletPreference will remain in the database and cause an error in the My Subscriptions portlet.

```
error message appears "My Subscriptions is temporarily unavailable" and in the log the exemption: 
-"com.liferay.portal.NoSuchPortletPreferencesException: No PortletPreferences exists with the primary key *****"
```

What VerifySubscriptions does is it that deletes these "orphaned" subscription entries.

Thank you.

Best regards,
István
