### PR TITLE
LPS-59047 Orphaned Subscription records stay in the database even after applying LPS-45418

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSubscription.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSubscription.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowInstance;
 import com.liferay.portal.model.Layout;
+import com.liferay.portal.model.PortletPreferences;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portlet.blogs.model.BlogsEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
@@ -66,8 +67,20 @@ public class UpgradeSubscription extends UpgradeProcess {
 		}
 	}
 
+	protected void deleteOrphanedSubscriptions() throws Exception {
+		long classNameId = PortalUtil.getClassNameId(
+			PortletPreferences.class.getName());
+
+		runSQL(
+			"delete from Subscription where classNameId = " + classNameId +
+			" and classPK not in (select portletPreferencesId" +
+			" from PortletPreferences)");
+	}
+
 	@Override
 	protected void doUpgrade() throws Exception {
+		deleteOrphanedSubscriptions();
+
 		updateSubscriptionClassNames(
 			Folder.class.getName(), DLFolder.class.getName());
 		updateSubscriptionClassNames(


### PR DESCRIPTION
Hey @sergiogonzalez 

After incorporating the modifications suggested in https://github.com/migue/liferay-portal/pull/535 I resend the pull for LPS-59047.

The subscriptions are now deleted with a single SQL statement, and instead of the verification process, the cleanup is done during upgrade to 7.0.0.

Thank you if you review it.

Best regards,
István
