### PR TITLE
LPS-61540 Thread attachments are lost when splitting Threads within Message Boards

### DIFF
--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBThreadLocalServiceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBThreadLocalServiceTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portlet.messageboards.model.MBCategoryConstants;
+import com.liferay.portlet.messageboards.model.MBMessage;
+import com.liferay.portlet.messageboards.model.MBMessageConstants;
+import com.liferay.portlet.messageboards.service.MBMessageLocalServiceUtil;
+import com.liferay.portlet.messageboards.service.MBThreadLocalServiceUtil;
+import com.liferay.portlet.messageboards.util.test.MBTestUtil;
+
+import java.io.InputStream;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author István András Dézsi
+ */
+@RunWith(Arquillian.class)
+@Sync
+public class MBThreadLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testAttachmentsWhenSplittingThread() throws Exception {
+		MBMessage rootMessage = addMessage(null, false);
+		MBMessage splitMessage = addMessage(rootMessage, true);
+		MBMessage childMessage = addMessage(splitMessage, true);
+
+		Assert.assertEquals(
+			rootMessage.getThreadId(), splitMessage.getThreadId());
+
+		Assert.assertEquals(1, splitMessage.getAttachmentsFileEntriesCount());
+		Assert.assertEquals(1, childMessage.getAttachmentsFileEntriesCount());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		MBThreadLocalServiceUtil.splitThread(
+			TestPropsValues.getUserId(), splitMessage.getMessageId(),
+			RandomTestUtil.randomString(), serviceContext);
+
+		rootMessage = MBMessageLocalServiceUtil.getMBMessage(
+			rootMessage.getMessageId());
+
+		splitMessage = MBMessageLocalServiceUtil.getMBMessage(
+			splitMessage.getMessageId());
+
+		Assert.assertNotEquals(
+			rootMessage.getThreadId(), splitMessage.getThreadId());
+
+		Assert.assertEquals(1, splitMessage.getAttachmentsFileEntriesCount());
+		Assert.assertEquals(1, childMessage.getAttachmentsFileEntriesCount());
+	}
+
+	protected MBMessage addMessage(
+			MBMessage parentMessage, boolean addAttachments)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		long categoryId = MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID;
+		long parentMessageId = MBMessageConstants.DEFAULT_PARENT_MESSAGE_ID;
+		long threadId = 0;
+
+		if (parentMessage != null) {
+			categoryId = parentMessage.getCategoryId();
+			parentMessageId = parentMessage.getMessageId();
+			threadId = parentMessage.getThreadId();
+		}
+
+		List<ObjectValuePair<String, InputStream>> inputStreamOVPs =
+			Collections.emptyList();
+
+		if (addAttachments) {
+			inputStreamOVPs = MBTestUtil.getInputStreamOVPs(
+				"attachment.txt", getClass(), StringPool.BLANK);
+		}
+
+		return MBMessageLocalServiceUtil.addMessage(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			_group.getGroupId(), categoryId, threadId, parentMessageId,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			MBMessageConstants.DEFAULT_FORMAT, inputStreamOVPs, false, 0.0,
+			false, serviceContext);
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/resources/com/liferay/message/boards/service/test/dependencies/attachment.txt
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/resources/com/liferay/message/boards/service/test/dependencies/attachment.txt
@@ -1,0 +1,1 @@
+Test Attachment

--- a/portal-impl/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryImpl.java
@@ -645,7 +645,7 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 
 	@Override
 	public Folder movePortletFolder(
-			long userId, long folderId, long parentFolderId,
+			long groupId, long userId, long folderId, long parentFolderId,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -655,7 +655,7 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 			DLAppHelperThreadLocal.setEnabled(false);
 
 			LocalRepository localRepository =
-				RepositoryProviderUtil.getFolderLocalRepository(parentFolderId);
+				RepositoryProviderUtil.getLocalRepository(groupId);
 
 			return localRepository.moveFolder(
 				userId, folderId, parentFolderId, serviceContext);

--- a/portal-impl/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryImpl.java
@@ -644,6 +644,28 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 	}
 
 	@Override
+	public Folder movePortletFolder(
+			long userId, long folderId, long parentFolderId,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		boolean dlAppHelperEnabled = DLAppHelperThreadLocal.isEnabled();
+
+		try {
+			DLAppHelperThreadLocal.setEnabled(false);
+
+			LocalRepository localRepository =
+				RepositoryProviderUtil.getFolderLocalRepository(parentFolderId);
+
+			return localRepository.moveFolder(
+				userId, folderId, parentFolderId, serviceContext);
+		}
+		finally {
+			DLAppHelperThreadLocal.setEnabled(dlAppHelperEnabled);
+		}
+	}
+
+	@Override
 	public void restorePortletFileEntryFromTrash(long userId, long fileEntryId)
 		throws PortalException {
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBThreadLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBThreadLocalServiceImpl.java
@@ -1318,8 +1318,8 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 			long newThreadFolderId = newThreadFolder.getFolderId();
 
 			PortletFileRepositoryUtil.movePortletFolder(
-				message.getUserId(), folderId, newThreadFolderId,
-				serviceContext);
+				message.getGroupId(), message.getUserId(), folderId,
+				newThreadFolderId, serviceContext);
 		}
 
 		List<MBMessage> childMessages = mbMessagePersistence.findByT_P(

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBThreadLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBThreadLocalServiceImpl.java
@@ -1164,7 +1164,7 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 		// Attachments
 
 		moveAttachmentsFolders(
-			message, oldAttachmentsFolderId, thread, serviceContext);
+			message, oldAttachmentsFolderId, oldThread, thread, serviceContext);
 
 		// Indexer
 
@@ -1308,8 +1308,8 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 	}
 
 	protected void moveAttachmentsFolders(
-			MBMessage message, long oldAttachmentsFolderId, MBThread newThread,
-			ServiceContext serviceContext)
+			MBMessage message, long oldAttachmentsFolderId, MBThread oldThread,
+			MBThread newThread, ServiceContext serviceContext)
 		throws PortalException {
 
 		if (oldAttachmentsFolderId !=
@@ -1324,12 +1324,12 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 		}
 
 		List<MBMessage> childMessages = mbMessagePersistence.findByT_P(
-			message.getThreadId(), message.getMessageId());
+			oldThread.getThreadId(), message.getMessageId());
 
 		for (MBMessage childMessage : childMessages) {
 			moveAttachmentsFolders(
-				childMessage, childMessage.getAttachmentsFolderId(), newThread,
-				serviceContext);
+				childMessage, childMessage.getAttachmentsFolderId(), oldThread,
+				newThread, serviceContext);
 		}
 	}
 

--- a/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepository.java
+++ b/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepository.java
@@ -169,6 +169,11 @@ public interface PortletFileRepository {
 			long groupId, long userId, long folderId, String fileName)
 		throws PortalException;
 
+	public Folder movePortletFolder(
+			long userId, long folderId, long parentFolderId,
+			ServiceContext serviceContext)
+		throws PortalException;
+
 	public void restorePortletFileEntryFromTrash(long userId, long fileEntryId)
 		throws PortalException;
 

--- a/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepository.java
+++ b/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepository.java
@@ -170,7 +170,7 @@ public interface PortletFileRepository {
 		throws PortalException;
 
 	public Folder movePortletFolder(
-			long userId, long folderId, long parentFolderId,
+			long groupId, long userId, long folderId, long parentFolderId,
 			ServiceContext serviceContext)
 		throws PortalException;
 

--- a/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryUtil.java
+++ b/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryUtil.java
@@ -316,6 +316,15 @@ public class PortletFileRepositoryUtil {
 			groupId, userId, folderId, fileName);
 	}
 
+	public static Folder movePortletFolder(
+			long userId, long folderId, long parentFolderId,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return getPortletFileRepository().movePortletFolder(
+			userId, folderId, parentFolderId, serviceContext);
+	}
+
 	public static void restorePortletFileEntryFromTrash(
 			long userId, long fileEntryId)
 		throws PortalException {

--- a/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryUtil.java
+++ b/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryUtil.java
@@ -317,12 +317,12 @@ public class PortletFileRepositoryUtil {
 	}
 
 	public static Folder movePortletFolder(
-			long userId, long folderId, long parentFolderId,
+			long groupId, long userId, long folderId, long parentFolderId,
 			ServiceContext serviceContext)
 		throws PortalException {
 
 		return getPortletFileRepository().movePortletFolder(
-			userId, folderId, parentFolderId, serviceContext);
+			groupId, userId, folderId, parentFolderId, serviceContext);
 	}
 
 	public static void restorePortletFileEntryFromTrash(


### PR DESCRIPTION
Hey @sergiogonzalez 

Thanks for your remarks in https://github.com/IstvanD/liferay-portal/pull/20.

There were just a minor thing which I had to correct further.
The child messages won't be found here

```
List<MBMessage> childMessages = mbMessagePersistence.findByT_P(
            message.getThreadId(), message.getMessageId());
```

because message will have already a new thread ID, but it's child messages will still belong to the previous thread.

With keeping the ID if the previous thread, the child messages can be retrieved

```
List<MBMessage> childMessages = mbMessagePersistence.findByT_P(
            oldThread.getThreadId(), message.getMessageId());
```

Also, I added a MBThreadLocalServiceTest class to the Message Boards module, although I saw that a class with the same name exists in portal-impl too.
However, I thought that it is preferred to write new test cases in modules, and the WikiPageLocalServiceTest example you gave me is in a module as well.

The testAttachmentsWhenSplittingThread() method inspects if the attachments are retained after splitting a thread.

Best regards,
Istfván
