### PR TITLE
LPS-63875 Links in RSS feeds not working for Message Boards referenced in layout templates

### DIFF
--- a/modules/apps/collaboration/blogs/blogs-web/src/main/java/com/liferay/blogs/web/portlet/action/RSSAction.java
+++ b/modules/apps/collaboration/blogs/blogs-web/src/main/java/com/liferay/blogs/web/portlet/action/RSSAction.java
@@ -18,6 +18,7 @@ import com.liferay.blogs.configuration.BlogsGroupServiceOverriddenConfiguration;
 import com.liferay.blogs.kernel.service.BlogsEntryService;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
 import com.liferay.portal.kernel.struts.StrutsAction;
@@ -53,6 +54,11 @@ public class RSSAction extends BaseRSSStrutsAction {
 		Layout layout = themeDisplay.getLayout();
 
 		long plid = ParamUtil.getLong(request, "p_l_id");
+
+		if (plid == LayoutConstants.DEFAULT_PLID) {
+			plid = themeDisplay.getPlid();
+		}
+
 		long companyId = ParamUtil.getLong(request, "companyId");
 		long groupId = ParamUtil.getLong(request, "groupId");
 		long organizationId = ParamUtil.getLong(request, "organizationId");

--- a/modules/apps/collaboration/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/portlet/action/RSSAction.java
+++ b/modules/apps/collaboration/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/portlet/action/RSSAction.java
@@ -16,6 +16,7 @@ package com.liferay.message.boards.web.portlet.action;
 
 import com.liferay.message.boards.kernel.service.MBMessageService;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.struts.StrutsAction;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -42,7 +43,12 @@ public class RSSAction extends BaseRSSStrutsAction {
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		String plid = ParamUtil.getString(request, "p_l_id");
+		long plid = ParamUtil.getLong(request, "p_l_id");
+
+		if (plid == LayoutConstants.DEFAULT_PLID) {
+			plid = themeDisplay.getPlid();
+		}
+
 		long companyId = ParamUtil.getLong(request, "companyId");
 		long groupId = ParamUtil.getLong(request, "groupId");
 		long userId = ParamUtil.getLong(request, "userId");


### PR DESCRIPTION
Hey Sergio,

Could you please review this pull request?

When an RSS link is generated, the parameter p_l_id will remain blank, because DynamicServletRequest (the wrapper for the HttpServletRequest where the plid would be taken from) is created with the inherit parameter set to false.
Because of this, the p_i_id parameter will not propagate from the HttpServletRequest to the DynamicServletRequest and ParamUtil.getString(request, "p_l_id") will return a blank string (the default value).

If a Message Boards portlet is added via a Layout Template, FindMessageAction will not locate the portlet when the plid is missing.

The same issue also arises with Blogs.

Note: I was not able to reproduce the issue on master because I could not deploy a Layout Template, and I could not add a feed URL in the RSS Publisher portlet configuration.
It is possible to reproduce the issue on 6.2.x though.

Thank you,
István
