### PR TITLE
LPS-67033 ClassPathUtil doesn't support JBoss 5 with VFSZIP

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/process/ClassPathUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/process/ClassPathUtil.java
@@ -228,7 +228,8 @@ public class ClassPathUtil {
 		}
 
 		if ((ServerDetector.isJBoss() || ServerDetector.isWildfly()) &&
-			(protocol.equals("vfs") || protocol.equals("vfsfile"))) {
+			(protocol.equals("vfs") || protocol.equals("vfsfile") ||
+			protocol.equals("vfszip"))) {
 
 			int pos = path.indexOf(".jar/");
 


### PR DESCRIPTION
Hey Sergio,

Could you please check this pull request?

I've sent the pull for you because a very similar pr was sent to you in the past (https://github.com/sergiogonzalez/liferay-portal/pull/176) but feel feel to forward it to the appropriate reviewer. 

Thank you!
István
