### PR TITLE
[TECHNICAL-SUPPORT] LPS-66188 When the Recycle Bin is disabled, deleting a previously parent Wiki page will also delete its former child page

### DIFF
--- a/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -506,11 +506,9 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			nodeId, title, false);
 
 		for (WikiPage oldPage : oldPages) {
-			if (!WorkflowThreadLocal.isEnabled()) {
-				oldPage.setParentTitle(originalParentTitle);
+			oldPage.setParentTitle(newParentTitle);
 
-				wikiPagePersistence.update(oldPage);
-			}
+			wikiPagePersistence.update(oldPage);
 		}
 
 		return page;


### PR DESCRIPTION
Hey @sergiogonzalez 

Another customer reported the issue LPS-66188.
A solution for it was sent in the past already https://github.com/sergiogonzalez/liferay-portal/pull/3182

In the pull request, you suggested another approach https://github.com/sergiogonzalez/liferay-portal/pull/3182#issuecomment-228997257, which I implemented in this pull request.
It sets the parentTitle of the older versions of the moved child page to the new parent's title.

Can you please take a look at it?

Thank you in advance.

Best regards,
István
