### PR TITLE
LPS-75491 External user invitation directs to login page instead of create account

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1746,8 +1746,19 @@ public class PortalImpl implements Portal {
 		throws Exception {
 
 		if (Validator.isNull(PropsValues.COMPANY_SECURITY_STRANGERS_URL)) {
-			PortletURL createAccountURL = PortletURLFactoryUtil.create(
-				request, PortletKeys.LOGIN, PortletRequest.RENDER_PHASE);
+			Layout layout = themeDisplay.getLayout();
+
+			PortletURL createAccountURL = null;
+
+			if (layout.isPrivateLayout()) {
+				createAccountURL = PortletURLFactoryUtil.create(
+					request, PortletKeys.LOGIN, null,
+					PortletRequest.RENDER_PHASE);
+			}
+			else {
+				createAccountURL = PortletURLFactoryUtil.create(
+					request, PortletKeys.LOGIN, PortletRequest.RENDER_PHASE);
+			}
 
 			createAccountURL.setParameter(
 				"saveLastPath", Boolean.FALSE.toString());


### PR DESCRIPTION
Hey @sergiogonzalez 

As you suggested in, https://github.com/sergiogonzalez/liferay-portal/pull/4196#issuecomment-361276491, I applied `PortletURLFactoryUtil.create` in each case.
However, I don't get the desired effect.
If the `layout` is private, I get navigated to the Welcome page, instead of the Create Account page.
I'm passing **null** as the `layout` to `PortletURLFactoryUtil.create` because that's the same layout value that `getPortalURL(ThemeDisplay themeDisplay)` is using.

However, I suppose that instead of this, we need some default, public layout, if the current layout turns out to be private.
But I don't know what that particular public layout should be.

Best regards,
István