### PR TITLE
LPS-75749 Notification event can be deleted by marking it

### DIFF
--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/search/UserNotificationEventRowChecker.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/search/UserNotificationEventRowChecker.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.notifications.web.internal.search;
+
+import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
+import com.liferay.portal.kernel.model.UserNotificationEvent;
+
+import javax.portlet.PortletResponse;
+
+/**
+ * @author István András Dézsi
+ */
+public class UserNotificationEventRowChecker extends EmptyOnClickRowChecker {
+
+	public UserNotificationEventRowChecker(PortletResponse portletResponse) {
+		super(portletResponse);
+	}
+
+	@Override
+	public boolean isDisabled(Object obj) {
+		UserNotificationEvent userNotificationEvent =
+			(UserNotificationEvent)obj;
+
+		if (!userNotificationEvent.isArchived()) {
+			return true;
+		}
+
+		return super.isDisabled(obj);
+	}
+
+}

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/init.jsp
@@ -24,10 +24,10 @@ taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.notifications.web.internal.util.NotificationsUtil" %><%@
+<%@ page import="com.liferay.notifications.web.internal.search.UserNotificationEventRowChecker" %><%@
+page import="com.liferay.notifications.web.internal.util.NotificationsUtil" %><%@
 page import="com.liferay.notifications.web.internal.util.comparator.PortletIdComparator" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
-page import="com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker" %><%@
 page import="com.liferay.portal.kernel.dao.search.SearchContainer" %><%@
 page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.json.JSONObject" %><%@

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
@@ -120,7 +120,7 @@ navigationURL.setParameter(SearchContainer.DEFAULT_CUR_PARAM, "0");
 	<aui:form action="<%= currentURL %>" method="get" name="fm">
 		<div class="user-notifications">
 			<liferay-ui:search-container
-				rowChecker="<%= new EmptyOnClickRowChecker(renderResponse) %>"
+				rowChecker="<%= new UserNotificationEventRowChecker(renderResponse) %>"
 				searchContainer="<%= notificationsSearchContainer %>"
 			>
 				<liferay-ui:search-container-row


### PR DESCRIPTION
Hey @sergiogonzalez 

I'm sorry to bothering you with this pull request, but @robertoDiaz is currently on vacation.

The QA team discovered a use case where [LPS-75749](https://issues.liferay.com/browse/LPS-75749) doesn't solve the issue, therefore I added a RowChecker that ensures that the row checkbox is disabled if the User Notification Event is not archived.

Could you please review this change?

Thank you in advance!

Best regards,
István