### PR TITLE
LPS-83373 In Wiki pages, list subitems within <ol type="a"> become numbered

### DIFF
--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/css/main.scss
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/css/main.scss
@@ -11,10 +11,6 @@
 			@include experimental(overflow-scrolling, touch);
 		}
 
-		ol ol {
-			list-style: decimal outside;
-		}
-
 		pre {
 			background : #FFF;
 			border: 1px dashed #2F6FAB;


### PR DESCRIPTION
Hi @sergiogonzalez 

Could you please review this pull request?

After publishing a Wiki page containing nested lists, the bulleting style appears to be digits even when the type is specified to alphabetical.
This is because decimal bullet points are explicitly declared in the stylesheet for nested lists in Wiki pages.

```
.portlet-wiki {
	.wiki-body {
		ol ol {
			list-style: decimal outside;
		}
```

The code was entered via [LPS-18926](https://issues.liferay.com/browse/LPS-18926). The issue cannot be reproduced in DXP/master, even when LPS-18926 is reverted. Therefore, I'm reverting LPS-18926 as it's no longer needed, and it solves the current issue.

As the fix only changes how the lists appear in the browser, it can only be tested manually. Therefore, no automatized unit test is needed to accompany this solution.

Thanks, and best regards,
István