### PR TITLE
LPS-76893 Images appear rotated in content

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-item-selector-impl/src/main/java/com/liferay/adaptive/media/image/item/selector/internal/FileEntryAMImageFileEntryItemSelectorReturnTypeResolver.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-item-selector-impl/src/main/java/com/liferay/adaptive/media/image/item/selector/internal/FileEntryAMImageFileEntryItemSelectorReturnTypeResolver.java
@@ -63,13 +63,13 @@ public class FileEntryAMImageFileEntryItemSelectorReturnTypeResolver
 		String previewURL = null;
 
 		if (fileEntry.getGroupId() == fileEntry.getRepositoryId()) {
-			previewURL = DLUtil.getPreviewURL(
+			previewURL = DLUtil.getImagePreviewURL(
 				fileEntry, fileEntry.getFileVersion(), themeDisplay,
-				_IMAGE_PREVIEW_QUERY_STRING, false, false);
+				StringPool.BLANK, false, false);
 		}
 		else {
 			previewURL = PortletFileRepositoryUtil.getPortletFileEntryURL(
-				themeDisplay, fileEntry, _IMAGE_PREVIEW_QUERY_STRING, false);
+				themeDisplay, fileEntry, _IMAGE_PREVIEW_QUERY_STRING , false);
 		}
 
 		fileEntryJSONObject.put("url", previewURL);

--- a/modules/apps/adaptive-media/adaptive-media-image-item-selector-impl/src/main/java/com/liferay/adaptive/media/image/item/selector/internal/FileEntryAMImageFileEntryItemSelectorReturnTypeResolver.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-item-selector-impl/src/main/java/com/liferay/adaptive/media/image/item/selector/internal/FileEntryAMImageFileEntryItemSelectorReturnTypeResolver.java
@@ -69,7 +69,7 @@ public class FileEntryAMImageFileEntryItemSelectorReturnTypeResolver
 		}
 		else {
 			previewURL = PortletFileRepositoryUtil.getPortletFileEntryURL(
-				themeDisplay, fileEntry, _IMAGE_PREVIEW_QUERY_STRING , false);
+				themeDisplay, fileEntry, _IMAGE_PREVIEW_QUERY_STRING, false);
 		}
 
 		fileEntryJSONObject.put("url", previewURL);

--- a/modules/apps/adaptive-media/adaptive-media-image-item-selector-impl/src/main/java/com/liferay/adaptive/media/image/item/selector/internal/FileEntryAMImageFileEntryItemSelectorReturnTypeResolver.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-item-selector-impl/src/main/java/com/liferay/adaptive/media/image/item/selector/internal/FileEntryAMImageFileEntryItemSelectorReturnTypeResolver.java
@@ -65,16 +65,18 @@ public class FileEntryAMImageFileEntryItemSelectorReturnTypeResolver
 		if (fileEntry.getGroupId() == fileEntry.getRepositoryId()) {
 			previewURL = DLUtil.getPreviewURL(
 				fileEntry, fileEntry.getFileVersion(), themeDisplay,
-				StringPool.BLANK, false, false);
+				_IMAGE_PREVIEW_QUERY_STRING, false, false);
 		}
 		else {
 			previewURL = PortletFileRepositoryUtil.getPortletFileEntryURL(
-				themeDisplay, fileEntry, StringPool.BLANK, false);
+				themeDisplay, fileEntry, _IMAGE_PREVIEW_QUERY_STRING, false);
 		}
 
 		fileEntryJSONObject.put("url", previewURL);
 
 		return fileEntryJSONObject.toString();
 	}
+
+	private static final String _IMAGE_PREVIEW_QUERY_STRING = "&imagePreview=1";
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-image-item-selector-impl/src/main/java/com/liferay/adaptive/media/image/item/selector/internal/FileEntryAMImageURLItemSelectorReturnTypeResolver.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-item-selector-impl/src/main/java/com/liferay/adaptive/media/image/item/selector/internal/FileEntryAMImageURLItemSelectorReturnTypeResolver.java
@@ -69,9 +69,9 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolver
 		String previewURL = null;
 
 		if (fileEntry.getGroupId() == fileEntry.getRepositoryId()) {
-			previewURL = DLUtil.getPreviewURL(
+			previewURL = DLUtil.getImagePreviewURL(
 				fileEntry, fileEntry.getFileVersion(), themeDisplay,
-				_IMAGE_PREVIEW_QUERY_STRING, false, false);
+				StringPool.BLANK, false, false);
 		}
 		else {
 			previewURL = PortletFileRepositoryUtil.getPortletFileEntryURL(

--- a/modules/apps/adaptive-media/adaptive-media-image-item-selector-impl/src/main/java/com/liferay/adaptive/media/image/item/selector/internal/FileEntryAMImageURLItemSelectorReturnTypeResolver.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-item-selector-impl/src/main/java/com/liferay/adaptive/media/image/item/selector/internal/FileEntryAMImageURLItemSelectorReturnTypeResolver.java
@@ -71,11 +71,11 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolver
 		if (fileEntry.getGroupId() == fileEntry.getRepositoryId()) {
 			previewURL = DLUtil.getPreviewURL(
 				fileEntry, fileEntry.getFileVersion(), themeDisplay,
-				StringPool.BLANK, false, false);
+				_IMAGE_PREVIEW_QUERY_STRING, false, false);
 		}
 		else {
 			previewURL = PortletFileRepositoryUtil.getPortletFileEntryURL(
-				themeDisplay, fileEntry, StringPool.BLANK, false);
+				themeDisplay, fileEntry, _IMAGE_PREVIEW_QUERY_STRING, false);
 		}
 
 		fileEntryJSONObject.put("defaultSource", previewURL);
@@ -116,6 +116,8 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolver
 
 		return sourceJSONObject;
 	}
+
+	private static final String _IMAGE_PREVIEW_QUERY_STRING = "&imagePreview=1";
 
 	@Reference
 	private MediaQueryProvider _mediaQueryProvider;

--- a/modules/apps/adaptive-media/adaptive-media-image-item-selector-test/src/testIntegration/java/com/liferay/adaptive/media/image/item/selector/internal/test/FileEntryAMImageFileEntryItemSelectorReturnTypeResolverTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-item-selector-test/src/testIntegration/java/com/liferay/adaptive/media/image/item/selector/internal/test/FileEntryAMImageFileEntryItemSelectorReturnTypeResolverTest.java
@@ -19,6 +19,7 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.item.selector.ItemSelectorReturnTypeResolver;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Group;
@@ -78,9 +79,9 @@ public class FileEntryAMImageFileEntryItemSelectorReturnTypeResolverTest {
 		long fileEntryId = jsonObject.getLong("fileEntryId");
 
 		Assert.assertEquals(
-			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null,
-				_IMAGE_PREVIEW_QUERY_STRING, false, false),
+			DLUtil.getImagePreviewURL(
+				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
+				false, false),
 			url);
 
 		Assert.assertEquals(fileEntry.getFileEntryId(), fileEntryId);
@@ -101,8 +102,6 @@ public class FileEntryAMImageFileEntryItemSelectorReturnTypeResolverTest {
 			FileEntryAMImageFileEntryItemSelectorReturnTypeResolverTest.class,
 			"image.jpg");
 	}
-
-	private static final String _IMAGE_PREVIEW_QUERY_STRING = "&imagePreview=1";
 
 	@Inject
 	private DLAppLocalService _dlAppLocalService;

--- a/modules/apps/adaptive-media/adaptive-media-image-item-selector-test/src/testIntegration/java/com/liferay/adaptive/media/image/item/selector/internal/test/FileEntryAMImageFileEntryItemSelectorReturnTypeResolverTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-item-selector-test/src/testIntegration/java/com/liferay/adaptive/media/image/item/selector/internal/test/FileEntryAMImageFileEntryItemSelectorReturnTypeResolverTest.java
@@ -19,7 +19,6 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.item.selector.ItemSelectorReturnTypeResolver;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Group;
@@ -80,8 +79,8 @@ public class FileEntryAMImageFileEntryItemSelectorReturnTypeResolverTest {
 
 		Assert.assertEquals(
 			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
-				false, false),
+				fileEntry, fileEntry.getFileVersion(), null,
+				_IMAGE_PREVIEW_QUERY_STRING, false, false),
 			url);
 
 		Assert.assertEquals(fileEntry.getFileEntryId(), fileEntryId);
@@ -102,6 +101,8 @@ public class FileEntryAMImageFileEntryItemSelectorReturnTypeResolverTest {
 			FileEntryAMImageFileEntryItemSelectorReturnTypeResolverTest.class,
 			"image.jpg");
 	}
+
+	private static final String _IMAGE_PREVIEW_QUERY_STRING = "&imagePreview=1";
 
 	@Inject
 	private DLAppLocalService _dlAppLocalService;

--- a/modules/apps/adaptive-media/adaptive-media-image-item-selector-test/src/testIntegration/java/com/liferay/adaptive/media/image/item/selector/internal/test/FileEntryAMImageURLItemSelectorReturnTypeResolverTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-item-selector-test/src/testIntegration/java/com/liferay/adaptive/media/image/item/selector/internal/test/FileEntryAMImageURLItemSelectorReturnTypeResolverTest.java
@@ -121,8 +121,8 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 
 		Assert.assertEquals(
 			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
-				false, false),
+				fileEntry, fileEntry.getFileVersion(), null,
+				_IMAGE_PREVIEW_QUERY_STRING, false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -166,8 +166,8 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 
 		Assert.assertEquals(
 			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
-				false, false),
+				fileEntry, fileEntry.getFileVersion(), null,
+				_IMAGE_PREVIEW_QUERY_STRING, false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -215,8 +215,8 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 
 		Assert.assertEquals(
 			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
-				false, false),
+				fileEntry, fileEntry.getFileVersion(), null,
+				_IMAGE_PREVIEW_QUERY_STRING, false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -256,8 +256,8 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 
 		Assert.assertEquals(
 			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
-				false, false),
+				fileEntry, fileEntry.getFileVersion(), null,
+				_IMAGE_PREVIEW_QUERY_STRING, false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -297,8 +297,8 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 
 		Assert.assertEquals(
 			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
-				false, false),
+				fileEntry, fileEntry.getFileVersion(), null,
+				_IMAGE_PREVIEW_QUERY_STRING, false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -338,8 +338,8 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 
 		Assert.assertEquals(
 			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
-				false, false),
+				fileEntry, fileEntry.getFileVersion(), null,
+				_IMAGE_PREVIEW_QUERY_STRING, false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -379,8 +379,8 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 
 		Assert.assertEquals(
 			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
-				false, false),
+				fileEntry, fileEntry.getFileVersion(), null,
+				_IMAGE_PREVIEW_QUERY_STRING, false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -420,8 +420,8 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 
 		Assert.assertEquals(
 			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
-				false, false),
+				fileEntry, fileEntry.getFileVersion(), null,
+				_IMAGE_PREVIEW_QUERY_STRING, false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -461,8 +461,8 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 
 		Assert.assertEquals(
 			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
-				false, false),
+				fileEntry, fileEntry.getFileVersion(), null,
+				_IMAGE_PREVIEW_QUERY_STRING, false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -502,8 +502,8 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 
 		Assert.assertEquals(
 			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
-				false, false),
+				fileEntry, fileEntry.getFileVersion(), null,
+				_IMAGE_PREVIEW_QUERY_STRING, false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -631,6 +631,8 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 			FileEntryAMImageURLItemSelectorReturnTypeResolverTest.class,
 			"image.jpg");
 	}
+
+	private static final String _IMAGE_PREVIEW_QUERY_STRING = "&imagePreview=1";
 
 	@Inject
 	private AMImageConfigurationHelper _amImageConfigurationHelper;

--- a/modules/apps/adaptive-media/adaptive-media-image-item-selector-test/src/testIntegration/java/com/liferay/adaptive/media/image/item/selector/internal/test/FileEntryAMImageURLItemSelectorReturnTypeResolverTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-item-selector-test/src/testIntegration/java/com/liferay/adaptive/media/image/item/selector/internal/test/FileEntryAMImageURLItemSelectorReturnTypeResolverTest.java
@@ -120,9 +120,9 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 		String defaultSource = jsonObject.getString("defaultSource");
 
 		Assert.assertEquals(
-			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null,
-				_IMAGE_PREVIEW_QUERY_STRING, false, false),
+			DLUtil.getImagePreviewURL(
+				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
+				false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -165,9 +165,9 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 		String defaultSource = jsonObject.getString("defaultSource");
 
 		Assert.assertEquals(
-			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null,
-				_IMAGE_PREVIEW_QUERY_STRING, false, false),
+			DLUtil.getImagePreviewURL(
+				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
+				false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -214,9 +214,9 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 		String defaultSource = jsonObject.getString("defaultSource");
 
 		Assert.assertEquals(
-			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null,
-				_IMAGE_PREVIEW_QUERY_STRING, false, false),
+			DLUtil.getImagePreviewURL(
+				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
+				false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -255,9 +255,9 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 		String defaultSource = jsonObject.getString("defaultSource");
 
 		Assert.assertEquals(
-			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null,
-				_IMAGE_PREVIEW_QUERY_STRING, false, false),
+			DLUtil.getImagePreviewURL(
+				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
+				false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -296,9 +296,9 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 		String defaultSource = jsonObject.getString("defaultSource");
 
 		Assert.assertEquals(
-			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null,
-				_IMAGE_PREVIEW_QUERY_STRING, false, false),
+			DLUtil.getImagePreviewURL(
+				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
+				false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -337,9 +337,9 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 		String defaultSource = jsonObject.getString("defaultSource");
 
 		Assert.assertEquals(
-			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null,
-				_IMAGE_PREVIEW_QUERY_STRING, false, false),
+			DLUtil.getImagePreviewURL(
+				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
+				false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -378,9 +378,9 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 		String defaultSource = jsonObject.getString("defaultSource");
 
 		Assert.assertEquals(
-			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null,
-				_IMAGE_PREVIEW_QUERY_STRING, false, false),
+			DLUtil.getImagePreviewURL(
+				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
+				false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -419,9 +419,9 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 		String defaultSource = jsonObject.getString("defaultSource");
 
 		Assert.assertEquals(
-			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null,
-				_IMAGE_PREVIEW_QUERY_STRING, false, false),
+			DLUtil.getImagePreviewURL(
+				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
+				false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -460,9 +460,9 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 		String defaultSource = jsonObject.getString("defaultSource");
 
 		Assert.assertEquals(
-			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null,
-				_IMAGE_PREVIEW_QUERY_STRING, false, false),
+			DLUtil.getImagePreviewURL(
+				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
+				false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -501,9 +501,9 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 		String defaultSource = jsonObject.getString("defaultSource");
 
 		Assert.assertEquals(
-			DLUtil.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null,
-				_IMAGE_PREVIEW_QUERY_STRING, false, false),
+			DLUtil.getImagePreviewURL(
+				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
+				false, false),
 			defaultSource);
 
 		JSONArray sourcesJSONArray = jsonObject.getJSONArray("sources");
@@ -631,8 +631,6 @@ public class FileEntryAMImageURLItemSelectorReturnTypeResolverTest {
 			FileEntryAMImageURLItemSelectorReturnTypeResolverTest.class,
 			"image.jpg");
 	}
-
-	private static final String _IMAGE_PREVIEW_QUERY_STRING = "&imagePreview=1";
 
 	@Inject
 	private AMImageConfigurationHelper _amImageConfigurationHelper;

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/resolver/FileEntryFileEntryItemSelectorReturnTypeResolver.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/resolver/FileEntryFileEntryItemSelectorReturnTypeResolver.java
@@ -63,13 +63,13 @@ public class FileEntryFileEntryItemSelectorReturnTypeResolver
 		String previewURL = null;
 
 		if (fileEntry.getGroupId() == fileEntry.getRepositoryId()) {
-			previewURL = DLUtil.getPreviewURL(
+			previewURL = DLUtil.getImagePreviewURL(
 				fileEntry, fileEntry.getFileVersion(), themeDisplay,
 				StringPool.BLANK, false, false);
 		}
 		else {
 			previewURL = PortletFileRepositoryUtil.getPortletFileEntryURL(
-				themeDisplay, fileEntry, StringPool.BLANK, false);
+				themeDisplay, fileEntry, _IMAGE_PREVIEW_QUERY_STRING, false);
 		}
 
 		fileEntryJSONObject.put("url", previewURL);
@@ -78,5 +78,7 @@ public class FileEntryFileEntryItemSelectorReturnTypeResolver
 
 		return fileEntryJSONObject.toString();
 	}
+
+	private static final String _IMAGE_PREVIEW_QUERY_STRING = "&imagePreview=1";
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
@@ -520,6 +520,10 @@ public class DLImpl implements DL {
 		FileEntry fileEntry, FileVersion fileVersion, ThemeDisplay themeDisplay,
 		String queryString, boolean appendVersion, boolean absoluteURL) {
 
+		if (Validator.isNull(queryString)) {
+			queryString = StringPool.BLANK;
+		}
+
 		if (ImageProcessorUtil.isSupported(fileVersion.getMimeType())) {
 			queryString = queryString.concat("&imagePreview=1");
 		}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
@@ -521,14 +521,14 @@ public class DLImpl implements DL {
 		String queryString, boolean appendVersion, boolean absoluteURL) {
 
 		if (ImageProcessorUtil.isSupported(fileVersion.getMimeType())) {
-			queryString.concat("&imagePreview=1");
+			queryString = queryString.concat("&imagePreview=1");
 		}
 		else if (PropsValues.DL_FILE_ENTRY_PREVIEW_ENABLED) {
 			if (PDFProcessorUtil.hasImages(fileVersion)) {
-				queryString.concat("&previewFileIndex=1");
+				queryString = queryString.concat("&previewFileIndex=1");
 			}
 			else if (VideoProcessorUtil.hasVideo(fileVersion)) {
-				queryString.concat("&videoThumbnail=1");
+				queryString = queryString.concat("&videoThumbnail=1");
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
@@ -463,7 +463,7 @@ public class DLImpl implements DL {
 	}
 
 	/**
-	 * @deprecated As of Judson, (7.1.x), with no direct replacement
+	 * @deprecated As of Judson (7.1.x), with no direct replacement
 	 */
 	@Deprecated
 	@Override
@@ -511,8 +511,8 @@ public class DLImpl implements DL {
 		FileEntry fileEntry, FileVersion fileVersion,
 		ThemeDisplay themeDisplay) {
 
-		return getImagePreviewURL(fileEntry, fileVersion, themeDisplay, null,
-			true, true);
+		return getImagePreviewURL(
+			fileEntry, fileVersion, themeDisplay, null, true, true);
 	}
 
 	@Override
@@ -711,7 +711,7 @@ public class DLImpl implements DL {
 	}
 
 	/**
-	 * @deprecated As of Wilberforce, (7.0.x), replaced by {@link
+	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
 	 *             #getThumbnailSrc(FileEntry, ThemeDisplay)}
 	 */
 	@Deprecated
@@ -726,7 +726,7 @@ public class DLImpl implements DL {
 	}
 
 	/**
-	 * @deprecated As of Wilberforce, (7.0.x), replaced by {@link
+	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
 	 *             #getThumbnailSrc(FileEntry, FileVersion, ThemeDisplay)}
 	 */
 	@Deprecated
@@ -1006,7 +1006,7 @@ public class DLImpl implements DL {
 	}
 
 	/**
-	 * @deprecated As of Judson, (7.1.x), replaced by {@link
+	 * @deprecated As of Judson (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFileEntryType(long, long,
 	 *             long, long)}
@@ -1028,7 +1028,7 @@ public class DLImpl implements DL {
 	}
 
 	/**
-	 * @deprecated As of Judson, (7.1.x), replaced by {@link
+	 * @deprecated As of Judson (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFolder(long, long, long,
 	 *             long)}
@@ -1043,7 +1043,7 @@ public class DLImpl implements DL {
 	}
 
 	/**
-	 * @deprecated As of Judson, (7.1.x), replaced by {@link
+	 * @deprecated As of Judson (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFolder(long, long, long,
 	 *             long, boolean)}
@@ -1196,8 +1196,8 @@ public class DLImpl implements DL {
 		FileEntry fileEntry, FileVersion fileVersion, ThemeDisplay themeDisplay,
 		String queryString) {
 
-		return getImageSrc(fileEntry, fileVersion, themeDisplay, queryString,
-			true, true);
+		return getImageSrc(
+			fileEntry, fileVersion, themeDisplay, queryString, true, true);
 	}
 
 	protected String getImageSrc(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
@@ -463,7 +463,7 @@ public class DLImpl implements DL {
 	}
 
 	/**
-	 * @deprecated As of Judson (7.1.x), with no direct replacement
+	 * @deprecated As of Judson, (7.1.x), with no direct replacement
 	 */
 	@Deprecated
 	@Override
@@ -508,26 +508,33 @@ public class DLImpl implements DL {
 
 	@Override
 	public String getImagePreviewURL(
-			FileEntry fileEntry, FileVersion fileVersion,
-			ThemeDisplay themeDisplay)
-		throws Exception {
+		FileEntry fileEntry, FileVersion fileVersion,
+		ThemeDisplay themeDisplay) {
 
-		String previewQueryString = null;
+		return getImagePreviewURL(fileEntry, fileVersion, themeDisplay, null,
+			true, true);
+	}
+
+	@Override
+	public String getImagePreviewURL(
+		FileEntry fileEntry, FileVersion fileVersion, ThemeDisplay themeDisplay,
+		String queryString, boolean appendVersion, boolean absoluteURL) {
 
 		if (ImageProcessorUtil.isSupported(fileVersion.getMimeType())) {
-			previewQueryString = "&imagePreview=1";
+			queryString.concat("&imagePreview=1");
 		}
 		else if (PropsValues.DL_FILE_ENTRY_PREVIEW_ENABLED) {
 			if (PDFProcessorUtil.hasImages(fileVersion)) {
-				previewQueryString = "&previewFileIndex=1";
+				queryString.concat("&previewFileIndex=1");
 			}
 			else if (VideoProcessorUtil.hasVideo(fileVersion)) {
-				previewQueryString = "&videoThumbnail=1";
+				queryString.concat("&videoThumbnail=1");
 			}
 		}
 
 		return getImageSrc(
-			fileEntry, fileVersion, themeDisplay, previewQueryString);
+			fileEntry, fileVersion, themeDisplay, queryString, appendVersion,
+			absoluteURL);
 	}
 
 	@Override
@@ -700,7 +707,7 @@ public class DLImpl implements DL {
 	}
 
 	/**
-	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
+	 * @deprecated As of Wilberforce, (7.0.x), replaced by {@link
 	 *             #getThumbnailSrc(FileEntry, ThemeDisplay)}
 	 */
 	@Deprecated
@@ -715,7 +722,7 @@ public class DLImpl implements DL {
 	}
 
 	/**
-	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
+	 * @deprecated As of Wilberforce, (7.0.x), replaced by {@link
 	 *             #getThumbnailSrc(FileEntry, FileVersion, ThemeDisplay)}
 	 */
 	@Deprecated
@@ -995,7 +1002,7 @@ public class DLImpl implements DL {
 	}
 
 	/**
-	 * @deprecated As of Judson (7.1.x), replaced by {@link
+	 * @deprecated As of Judson, (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFileEntryType(long, long,
 	 *             long, long)}
@@ -1017,7 +1024,7 @@ public class DLImpl implements DL {
 	}
 
 	/**
-	 * @deprecated As of Judson (7.1.x), replaced by {@link
+	 * @deprecated As of Judson, (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFolder(long, long, long,
 	 *             long)}
@@ -1032,7 +1039,7 @@ public class DLImpl implements DL {
 	}
 
 	/**
-	 * @deprecated As of Judson (7.1.x), replaced by {@link
+	 * @deprecated As of Judson, (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFolder(long, long, long,
 	 *             long, boolean)}
@@ -1182,15 +1189,23 @@ public class DLImpl implements DL {
 	}
 
 	protected String getImageSrc(
-			FileEntry fileEntry, FileVersion fileVersion,
-			ThemeDisplay themeDisplay, String queryString)
-		throws Exception {
+		FileEntry fileEntry, FileVersion fileVersion, ThemeDisplay themeDisplay,
+		String queryString) {
+
+		return getImageSrc(fileEntry, fileVersion, themeDisplay, queryString,
+			true, true);
+	}
+
+	protected String getImageSrc(
+		FileEntry fileEntry, FileVersion fileVersion, ThemeDisplay themeDisplay,
+		String queryString, boolean appendVersion, boolean absoluteURL) {
 
 		String thumbnailSrc = StringPool.BLANK;
 
 		if (Validator.isNotNull(queryString)) {
 			thumbnailSrc = getPreviewURL(
-				fileEntry, fileVersion, themeDisplay, queryString, true, true);
+				fileEntry, fileVersion, themeDisplay, queryString,
+				appendVersion, absoluteURL);
 		}
 
 		return thumbnailSrc;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/DL.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/DL.java
@@ -101,7 +101,7 @@ public interface DL {
 		FileEntry fileEntry, ThemeDisplay themeDisplay);
 
 	/**
-	 * @deprecated As of Judson (7.1.x), with no direct replacement
+	 * @deprecated As of Judson, (7.1.x), with no direct replacement
 	 */
 	@Deprecated
 	public Set<Long> getFileEntryTypeSubscriptionClassPKs(long userId);
@@ -116,6 +116,12 @@ public interface DL {
 			FileEntry fileEntry, FileVersion fileVersion,
 			ThemeDisplay themeDisplay)
 		throws Exception;
+
+	public String getImagePreviewURL(
+			FileEntry fileEntry, FileVersion fileVersion,
+			ThemeDisplay themeDisplay, String queryString,
+			boolean appendVersion, boolean absoluteURL)
+		throws PortalException;
 
 	public String getImagePreviewURL(
 			FileEntry fileEntry, ThemeDisplay themeDisplay)
@@ -142,7 +148,7 @@ public interface DL {
 	public String getTempFileId(long id, String version, String languageId);
 
 	/**
-	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
+	 * @deprecated As of Wilberforce, (7.0.x), replaced by {@link
 	 *             #getThumbnailSrc(FileEntry, ThemeDisplay)}
 	 */
 	@Deprecated
@@ -152,7 +158,7 @@ public interface DL {
 		throws Exception;
 
 	/**
-	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
+	 * @deprecated As of Wilberforce, (7.0.x), replaced by {@link
 	 *             #getThumbnailSrc(FileEntry, FileVersion, ThemeDisplay)}
 	 */
 	@Deprecated
@@ -208,7 +214,7 @@ public interface DL {
 	public abstract boolean isOfficeExtension(String extension);
 
 	/**
-	 * @deprecated As of Judson (7.1.x), replaced by {@link
+	 * @deprecated As of Judson, (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFileEntryType(long, long,
 	 *             long, long)}
@@ -218,7 +224,7 @@ public interface DL {
 		long companyId, long groupId, long userId, long fileEntryTypeId);
 
 	/**
-	 * @deprecated As of Judson (7.1.x), replaced by {@link
+	 * @deprecated As of Judson, (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFolder(long, long, long,
 	 *             long)}
@@ -229,7 +235,7 @@ public interface DL {
 		throws PortalException;
 
 	/**
-	 * @deprecated As of Judson (7.1.x), replaced by {@link
+	 * @deprecated As of Judson, (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFolder(long, long, long,
 	 *             long, boolean)}

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/DL.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/DL.java
@@ -101,7 +101,7 @@ public interface DL {
 		FileEntry fileEntry, ThemeDisplay themeDisplay);
 
 	/**
-	 * @deprecated As of Judson, (7.1.x), with no direct replacement
+	 * @deprecated As of Judson (7.1.x), with no direct replacement
 	 */
 	@Deprecated
 	public Set<Long> getFileEntryTypeSubscriptionClassPKs(long userId);
@@ -148,7 +148,7 @@ public interface DL {
 	public String getTempFileId(long id, String version, String languageId);
 
 	/**
-	 * @deprecated As of Wilberforce, (7.0.x), replaced by {@link
+	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
 	 *             #getThumbnailSrc(FileEntry, ThemeDisplay)}
 	 */
 	@Deprecated
@@ -158,7 +158,7 @@ public interface DL {
 		throws Exception;
 
 	/**
-	 * @deprecated As of Wilberforce, (7.0.x), replaced by {@link
+	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
 	 *             #getThumbnailSrc(FileEntry, FileVersion, ThemeDisplay)}
 	 */
 	@Deprecated
@@ -214,7 +214,7 @@ public interface DL {
 	public abstract boolean isOfficeExtension(String extension);
 
 	/**
-	 * @deprecated As of Judson, (7.1.x), replaced by {@link
+	 * @deprecated As of Judson (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFileEntryType(long, long,
 	 *             long, long)}
@@ -224,7 +224,7 @@ public interface DL {
 		long companyId, long groupId, long userId, long fileEntryTypeId);
 
 	/**
-	 * @deprecated As of Judson, (7.1.x), replaced by {@link
+	 * @deprecated As of Judson (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFolder(long, long, long,
 	 *             long)}
@@ -235,7 +235,7 @@ public interface DL {
 		throws PortalException;
 
 	/**
-	 * @deprecated As of Judson, (7.1.x), replaced by {@link
+	 * @deprecated As of Judson (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFolder(long, long, long,
 	 *             long, boolean)}

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/DLUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/DLUtil.java
@@ -140,7 +140,7 @@ public class DLUtil {
 	}
 
 	/**
-	 * @deprecated As of Judson (7.1.x), with no direct replacement
+	 * @deprecated As of Judson, (7.1.x), with no direct replacement
 	 */
 	@Deprecated
 	public static Set<Long> getFileEntryTypeSubscriptionClassPKs(long userId) {
@@ -165,6 +165,17 @@ public class DLUtil {
 		throws Exception {
 
 		return getDL().getImagePreviewURL(fileEntry, fileVersion, themeDisplay);
+	}
+
+	public static String getImagePreviewURL(
+			FileEntry fileEntry, FileVersion fileVersion,
+			ThemeDisplay themeDisplay, String queryString,
+			boolean appendVersion, boolean absoluteURL)
+		throws PortalException {
+
+		return getDL().getImagePreviewURL(
+			fileEntry, fileVersion, themeDisplay, queryString, appendVersion,
+			absoluteURL);
 	}
 
 	public static String getImagePreviewURL(
@@ -220,7 +231,7 @@ public class DLUtil {
 	}
 
 	/**
-	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
+	 * @deprecated As of Wilberforce, (7.0.x), replaced by {@link
 	 *             #getThumbnailSrc(FileEntry, ThemeDisplay)}
 	 */
 	@Deprecated
@@ -233,7 +244,7 @@ public class DLUtil {
 	}
 
 	/**
-	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
+	 * @deprecated As of Wilberforce, (7.0.x), replaced by {@link
 	 *             #getThumbnailSrc(FileEntry, FileVersion, ThemeDisplay)}
 	 */
 	@Deprecated
@@ -335,7 +346,7 @@ public class DLUtil {
 	}
 
 	/**
-	 * @deprecated As of Judson (7.1.x), replaced by {@link
+	 * @deprecated As of Judson, (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFileEntryType(long, long,
 	 *             long, long)}
@@ -349,7 +360,7 @@ public class DLUtil {
 	}
 
 	/**
-	 * @deprecated As of Judson (7.1.x), replaced by {@link
+	 * @deprecated As of Judson, (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFolder(long, long, long,
 	 *             long)}
@@ -364,7 +375,7 @@ public class DLUtil {
 	}
 
 	/**
-	 * @deprecated As of Judson (7.1.x), replaced by {@link
+	 * @deprecated As of Judson, (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFolder(long, long, long,
 	 *             long, boolean)}

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/DLUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/DLUtil.java
@@ -140,7 +140,7 @@ public class DLUtil {
 	}
 
 	/**
-	 * @deprecated As of Judson, (7.1.x), with no direct replacement
+	 * @deprecated As of Judson (7.1.x), with no direct replacement
 	 */
 	@Deprecated
 	public static Set<Long> getFileEntryTypeSubscriptionClassPKs(long userId) {
@@ -231,7 +231,7 @@ public class DLUtil {
 	}
 
 	/**
-	 * @deprecated As of Wilberforce, (7.0.x), replaced by {@link
+	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
 	 *             #getThumbnailSrc(FileEntry, ThemeDisplay)}
 	 */
 	@Deprecated
@@ -244,7 +244,7 @@ public class DLUtil {
 	}
 
 	/**
-	 * @deprecated As of Wilberforce, (7.0.x), replaced by {@link
+	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
 	 *             #getThumbnailSrc(FileEntry, FileVersion, ThemeDisplay)}
 	 */
 	@Deprecated
@@ -346,7 +346,7 @@ public class DLUtil {
 	}
 
 	/**
-	 * @deprecated As of Judson, (7.1.x), replaced by {@link
+	 * @deprecated As of Judson (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFileEntryType(long, long,
 	 *             long, long)}
@@ -360,7 +360,7 @@ public class DLUtil {
 	}
 
 	/**
-	 * @deprecated As of Judson, (7.1.x), replaced by {@link
+	 * @deprecated As of Judson (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFolder(long, long, long,
 	 *             long)}
@@ -375,7 +375,7 @@ public class DLUtil {
 	}
 
 	/**
-	 * @deprecated As of Judson, (7.1.x), replaced by {@link
+	 * @deprecated As of Judson (7.1.x), replaced by {@link
 	 *             com.liferay.document.library.web.internal.util.
 	 *             DLSubscriptionUtil#isSubscribedToFolder(long, long, long,
 	 *             long, boolean)}

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0


### PR DESCRIPTION
Hi @sergiogonzalez 

Could you please review this pull request?
This fix ensures an image preview is selected instead of the original image, which may be not properly processed, for example, it has a wrong EXIF orientation.

Thank you and have a nice weekend!

Bests,
István